### PR TITLE
Make sure url separators on Windows are /'s

### DIFF
--- a/lib/writers/file-writer.js
+++ b/lib/writers/file-writer.js
@@ -279,7 +279,7 @@ module.exports = function fileWriter(fileWriterConfig, optimizerConfig) {
             basename += '.' + targetExt;
         }
 
-        return nodePath.join(dirname, basename);
+        return nodePath.join(dirname, basename).replace(/[\\]/g, '/');
     }
 
     function getResourceUrl(path, context) {


### PR DESCRIPTION
I didn't bump version of module as don't know your numbering with respect to "beta". Please bump and publish. It did fix the use case I tried on Windows where all the <script> tags were showing backslashes.
