### PR TITLE
Update dependency-resource.js

### DIFF
--- a/lib/dependencies/dependency-resource.js
+++ b/lib/dependencies/dependency-resource.js
@@ -94,7 +94,7 @@ module.exports = {
         if (this.url) {
             return createUrlReadStream(this.url);
         } else {
-            return fs.createReadStream(this.path, 'utf8');
+            return fs.createReadStream(this.path, {encoding: 'utf8'});
         }
     },
 


### PR DESCRIPTION
Pass an object instead of a string as a second argument to fs.createReadStream. Otherwise an exception gets thrown (at least for the node version I am using - v1.6.1  (io.js) )