### PR TITLE
add mask-define option for resource dependencies

### DIFF
--- a/lib/dependencies/dependency-resource.js
+++ b/lib/dependencies/dependency-resource.js
@@ -46,12 +46,17 @@ function createUrlReadStream(url) {
     return stream;
 }
 
+function maskDefine(code) {
+    return '(function(define) { // START: lasso wrapper\n' + code + '\n}()); // END: lasso wrapper';
+}
+
 module.exports = {
     properties: {
         'path': 'string',
         'url': 'string',
         'code': 'string',
-        'external': 'boolean'
+        'external': 'boolean',
+        'mask-define': 'boolean'
     },
 
     init: function(lassoContext, callback) {
@@ -86,15 +91,28 @@ module.exports = {
         return this._dir;
     },
 
-    read: function(context) {
+    read: function(context, callback) {
         if (this.code){
             return this.code;
         }
 
-        if (this.url) {
-            return createUrlReadStream(this.url);
+        // if mask-define, use callback to wrap the resource
+        if (this['mask-define'] === true) {
+            fs.readFile(this.path, {encoding: 'utf8'}, function (err, code) {
+                if (err) {
+                    return callback(err);
+                }
+                callback(null, maskDefine(code));
+            });
+            return;
+
+        // otherwise return a stream
         } else {
-            return fs.createReadStream(this.path, {encoding: 'utf8'});
+            if (this.url) {
+                return createUrlReadStream(this.url);
+            } else {
+                return fs.createReadStream(this.path, {encoding: 'utf8'});
+            }
         }
     },
 

--- a/test/fixtures/mask-define/library.js
+++ b/test/fixtures/mask-define/library.js
@@ -1,0 +1,15 @@
+(function () {
+    'use strict';
+
+    function Library() {}
+
+    if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
+        define(function() {
+            return Library;
+        });
+    } else if (typeof module !== 'undefined' && module.exports) {
+        module.exports.Library = Library;
+    } else {
+        window.Library = Library;
+    }
+}());

--- a/test/lasso-test.js
+++ b/test/lasso-test.js
@@ -711,6 +711,35 @@ describe('lasso/index', function() {
             });
     });
 
+    it('should mask define in resources when mask-define option is true', function(done) {
+        var lasso = require('../');
+        var theLasso = lasso.create({
+            outputDir: outputDir,
+            urlPrefix: '/',
+            fingerprintsEnabled: false,
+            bundlingEnabled: true
+        }, __dirname, __filename);
+
+        var writerTracker = require('./WriterTracker').create(theLasso.writer);
+        theLasso.lassoPage({
+            pageName: 'mask-define-page',
+            cache: false,
+            dependencies: [
+                {
+                    "path": path.join(__dirname, './fixtures/mask-define/library.js'),
+                    "mask-define": true
+                }
+            ]
+        })
+            .then(function(lassoPageResult) {
+                var testCode = writerTracker.getCodeForFilename('mask-define-page.js');
+                expect(testCode).to.contain('(function(define) { // START: lasso wrapper\n');
+                expect(testCode).to.contain('\n}()); // END: lasso wrapper');
+                lasso.flushAllCaches(done);
+            })
+            .done();
+    });
+
     it('should lasso a page that has an installed module that uses async loading', function(done) {
         var lasso = require('../');
         var theLasso = lasso.create({


### PR DESCRIPTION
Added the `mask-define` option. This can be useful to skip the `define` check when including libraries with a UMD-style wrapper. Let me know of any changes needed.