### PR TITLE
Fixes #91 - Lasso config defaults get polluted each time Lasso is configured

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -96,7 +96,13 @@ function load(options, baseDir, filename, configDefaults) {
     }
 
     if (configDefaults) {
-        options = extend(configDefaults, options);
+        for (var key in configDefaults) {
+            // copy defaults to options only if options doesn't already
+            // have that property
+            if (configDefaults.hasOwnProperty(key) && !options.hasOwnProperty(key)) {
+                options[key] = configDefaults[key];
+            }
+        }
     }
 
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -15,8 +15,8 @@
         "runs"
     ],
 
-    "globals": { 
-        "define": true, 
+    "globals": {
+        "define": true,
         "require": true
     },
 
@@ -46,7 +46,6 @@
     "eqeqeq": false,
     "latedef": true,
     "unused": "vars",
-    
-    /* Relaxing options: */
-    "eqnull": true
+    "eqnull": true,
+    "expr": true
 }

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,0 +1,57 @@
+'use strict';
+var chai = require('chai');
+chai.Assertion.includeStack = true;
+require('chai').should();
+var expect = require('chai').expect;
+var nodePath = require('path');
+var util = require('./util');
+var outputDir = nodePath.join(__dirname, 'build');
+
+require('app-module-path').addPath(nodePath.join(__dirname, 'src'));
+
+describe('lasso-require' , function() {
+
+    beforeEach(function(done) {
+
+        util.rmdirRecursive(outputDir);
+
+        for (var k in require.cache) {
+            if (require.cache.hasOwnProperty(k)) {
+                delete require.cache[k];
+            }
+        }
+
+        require('raptor-promises').enableLongStacks();
+
+        require('raptor-logging').configureLoggers({
+            // 'raptor-cache': 'WARN',
+            // 'lasso/lib/page-bundles-builder': 'WARN',
+            // 'lasso/perf': 'WARN'
+            'raptor-cache': 'WARN',
+            'lasso': 'WARN',
+            'lasso-debug': 'WARN'
+        });
+
+        done();
+    });
+
+    it('should not pollute default configuration (issue #91)', function() {
+        var lasso = require('../');
+
+        var myLasso1 = lasso.create({
+            require: {
+                test: 'abc'
+            }
+        }, nodePath.join(__dirname, 'test-project'));
+
+        var myLasso2 = lasso.create({
+
+        }, nodePath.join(__dirname, 'test-project'));
+
+        var requirePlugin1 = myLasso1.getConfig().getPlugins()[0];
+        var requirePlugin2 = myLasso2.getConfig().getPlugins()[0];
+
+        expect(requirePlugin1.config.test).to.equal('abc');
+        expect(requirePlugin2.config.test).to.not.exist;
+    });
+});


### PR DESCRIPTION
Fix: don't copy `options` into `configDefaults`. Instead, copy `configDefaults` into `options` (don't override any properties that `options` already has).