### PR TITLE
Fixes #108 - Add support for fingerprinting inline code blocks for building SPA with CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Changelog
 
 - Adds support for injecting a Content Security Policy nonce into inline script and style tags. Fixes [Issue #93](https://github.com/lasso-js/lasso/issues/93)
 
+### 1.16.0
+
+- Adds support for fingerprinting inline code blocks for purpose of
+  creating Content Security Policy (CSP) that secures statically built app.
+
 ## 1.14.x
 
 ### 1.14.0

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -151,6 +151,7 @@ function Config(params) {
     this._requirePluginConfig = {};
     this._imagePluginConfig = {};
     this.cspNonceProvider = null;
+    this.fingerprintInlineCode = null;
 
     if (params) {
         extend(this.params, params);
@@ -388,6 +389,10 @@ Config.prototype = {
 
     setCSPNonceProvider: function(func) {
         this.cspNonceProvider = func;
+    },
+
+    setFingerprintInlineCode: function(func) {
+        this.fingerprintInlineCode = func;
     }
 };
 

--- a/lib/Lasso.js
+++ b/lib/Lasso.js
@@ -183,7 +183,17 @@ function doLassoPage(theLasso, options, lassoContext, callback) {
 
         var writer = lassoContext.writer;
 
+        // Inline code fingerprinting is useful for building a Single Page App
+        // that is using a Content Security Policy (CSP) that prevents
+        // untrusted script blocks. By keeping track of inline code
+        // fingerprints, a build tool could provide these as part of the CSP
+        // so that inline code blocks created at build time will be trusted.
+        var fingerprintInlineCode = config.fingerprintInlineCode;
+        var inlineCodeFingerprints;
 
+        if (fingerprintInlineCode) {
+            inlineCodeFingerprints = [];
+        }
 
         function onBundleWritten(bundle) {
             if (logInfoEnabled) {
@@ -205,6 +215,13 @@ function doLassoPage(theLasso, options, lassoContext, callback) {
                     url;
 
                 if (bundle.isInline()) {
+                    if (fingerprintInlineCode) {
+                        var fingerprint = config.fingerprintInlineCode(bundle.getCode());
+                        if (fingerprint) {
+                            inlineCodeFingerprints.push(fingerprint);
+                        }
+                    }
+
                     slotTracker.addInlineCode(bundle.getSlot(), bundle.getContentType(), bundle.getCode(), bundle.getInlinePos(), bundle.isMergeInline());
                 } else {
                     url = bundle.getUrl(lassoContext);
@@ -224,6 +241,7 @@ function doLassoPage(theLasso, options, lassoContext, callback) {
             });
 
             lassoPageResult.setHtmlBySlot(slotTracker.getHtmlBySlot());
+            lassoPageResult.setInlineCodeFingerprints(inlineCodeFingerprints);
         }
 
         var pageBundles;
@@ -645,6 +663,8 @@ Lasso.prototype = {
             deferred = raptorPromises.defer();
         }
 
+        var lassoContext = options.lassoContext || this.createLassoContext(options);
+
         function done(e, lassoPageResult) {
             if (e) {
                 if (deferred) {
@@ -660,12 +680,16 @@ Lasso.prototype = {
                 deferred.resolve(lassoPageResult);
             }
 
+            _this.emit('afterLassoPage', {
+                context: lassoContext,
+                lasso: _this,
+                result: lassoPageResult
+            });
+
             if (callback) {
                 callback(null, lassoPageResult);
             }
         }
-
-        var lassoContext = options.lassoContext || this.createLassoContext(options);
 
         if (options.cache !== false) {
 
@@ -680,6 +704,7 @@ Lasso.prototype = {
 
                         // Reuse the same lasso context
                         options.lassoContext = lassoContext;
+
                         doLassoPage(_this, options, lassoContext, callback);
                     }
                 },

--- a/lib/LassoPageResult.js
+++ b/lib/LassoPageResult.js
@@ -25,6 +25,13 @@ function LassoPageResult() {
     this._htmlBySlot = {};
 
     this._htmlTemplatesBySlot = {};
+
+    /**
+     * If Lasso is configured to fingerprint inline code for
+     * the purpose of Content Security Policy then this property
+     * will store the array of fingerprints.
+     */
+    this._inlineCodeFingerprints = undefined;
 }
 
 LassoPageResult.deserialize = function(reader, callback) {
@@ -46,8 +53,7 @@ LassoPageResult.deserialize = function(reader, callback) {
 };
 
 LassoPageResult.serialize = function(lassoPageResult) {
-    var json = JSON.stringify(lassoPageResult);
-    return json;
+    return JSON.stringify(lassoPageResult);
 };
 
 LassoPageResult.prototype = {
@@ -258,6 +264,14 @@ LassoPageResult.prototype = {
     getUrlByAsyncBundleName: function(bundleName) {
         var info = this.infoByAsyncBundleName[bundleName];
         return info && info.url;
+    },
+
+    getInlineCodeFingerprints: function() {
+        return this._inlineCodeFingerprints;
+    },
+
+    setInlineCodeFingerprints: function(inlineCodeFingerprints) {
+        this._inlineCodeFingerprints = inlineCodeFingerprints;
     }
 };
 

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -372,6 +372,14 @@ function load(options, baseDir, filename, configDefaults) {
             }
 
             config.setCSPNonceProvider(value);
+        },
+
+        fingerprintInlineCode: function(value) {
+            if (typeof value !== 'function') {
+                throw new Error('"fingerprintInlineCode" should be a function');
+            }
+
+            config.setFingerprintInlineCode(value);
         }
     };
 


### PR DESCRIPTION
This change allows a build tool to create and capture fingerprints for all inline code blocks for the purpose of generating a Content Security Policy. This change is especially useful for building single page apps which are statically built once and cannot leverage a _nonce_.

The solution in this pull request will also work when the lasso page result is serialized to cache and deserialized from cache.