### PR TITLE
registerRequireType, switch condition blocks

### DIFF
--- a/lib/dependencies/DependencyRegistry.js
+++ b/lib/dependencies/DependencyRegistry.js
@@ -289,9 +289,9 @@ DependencyRegistry.prototype = {
                     },
                     _requireGetLastModified: function(callback) {
                         if (requireGetLastModified) {
-                            callback(null, -1);
-                        } else {
                             requireGetLastModified.call(_this, lassoContext, callback);
+                        } else {
+                            callback(null, -1);
                         }
                     }
                 }


### PR DESCRIPTION
This caused an issue with my plugin when I did not define the optional `getLastModified` but the app crashed and the stack trace said it could not find said method. Looking at the source it appears these blocks should be flipped.