### PR TITLE
Fixes #117 - external dependency url improperly encoded

### DIFF
--- a/lib/Lasso.js
+++ b/lib/Lasso.js
@@ -3,7 +3,6 @@ var LassoCache = require('./LassoCache');
 var LassoPageResult = require('./LassoPageResult');
 var LassoContext = require('./LassoContext');
 var SlotTracker = require('./SlotTracker');
-var escapeXmlAttr = require('raptor-util/escapeXml').attr;
 var logger = require('raptor-logging').logger(module);
 var EventEmitter = require('events').EventEmitter;
 var mime = require('mime');
@@ -594,11 +593,11 @@ Lasso.prototype = {
     },
 
     getJavaScriptDependencyHtml: function(url) {
-        return '<script src="' + escapeXmlAttr(url) + '" ${data.externalScriptAttrs}></script>';
+        return '<script src="' + url + '" ${data.externalScriptAttrs}></script>';
     },
 
     getCSSDependencyHtml: function(url) {
-        return '<link rel="stylesheet" href="' + escapeXmlAttr(url) + '" ${data.externalStyleAttrs}>';
+        return '<link rel="stylesheet" href="' + url + '" ${data.externalStyleAttrs}>';
     },
 
     _resolveflags: function(options) {

--- a/test/lasso-test.js
+++ b/test/lasso-test.js
@@ -676,6 +676,58 @@ describe('lasso/index', function() {
             .done();
     });
 
+    it('should escape external js resource URLs', function(done) {
+        var lasso = require('../');
+        var theLasso = lasso.create({
+            flags: [],
+            fileWriter: {
+                outputDir: outputDir,
+                fingerprintsEnabled: false
+            },
+            bundles: []
+        }, __dirname, __filename);
+        theLasso.lassoPage({
+                pageName: 'testPage',
+                dependencies: {
+                    type: 'js',
+                    url: 'https://maps.googleapis.com/maps/api/js?key=KEY&callback=CB'
+                },
+                from: module
+            })
+            .then(function(lassoPageResult) {
+                expect(lassoPageResult.getBodyHtml()).to.equal('<script src="https://maps.googleapis.com/maps/api/js?key=KEY&amp;callback=CB"></script>');
+                expect(lassoPageResult.getHeadHtml()).to.equal('');
+                lasso.flushAllCaches(done);
+            })
+            .done();
+    });
+
+    it('should escape external css resource URLs', function(done) {
+        var lasso = require('../');
+        var theLasso = lasso.create({
+            flags: [],
+            fileWriter: {
+                outputDir: outputDir,
+                fingerprintsEnabled: false
+            },
+            bundles: []
+        }, __dirname, __filename);
+        theLasso.lassoPage({
+                pageName: 'testPage',
+                dependencies: {
+                    type: 'css',
+                    url: 'https://fonts.googleapis.com/css?family=Open+Sans&subset=latin'
+                },
+                from: module
+            })
+            .then(function(lassoPageResult) {
+                expect(lassoPageResult.getBodyHtml()).to.equal('');
+                expect(lassoPageResult.getHeadHtml()).to.equal('<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans&amp;subset=latin">');
+                lasso.flushAllCaches(done);
+            })
+            .done();
+    });
+
     it('should allow for external resource URLs to be inlined', function(done) {
         this.timeout(5000);
         var lasso = require('../');


### PR DESCRIPTION
It looks like since the addition of custom resource attributes from #107, external url strings will always get parsed through Marko and get escaped. Therefore, I've removed `escapeXmlAttr` in those cases so that they don't get double escaped. Let me know if you'd like to fix this in some other way (escape it explicitly and disable escaping through Marko?)