### PR TITLE
Updating the latest 1.x version of lasso-require

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lasso-image": "^1.0.9",
     "lasso-minify-css": "^1.0.0",
     "lasso-minify-js": "^1.1.4",
-    "lasso-require": "^1.4.0",
+    "lasso-require": "^1.8.0",
     "lasso-resolve-css-urls": "^1.0.0",
     "marko": "^2.8.0",
     "mime": "~1.2.7",


### PR DESCRIPTION
Teams have a direct dependency on `lasso` and this will help update to the latest version of `lasso-require`. Can you please merge this and publish a new 1.x `lasso` module.