### PR TITLE
Upgrade lasso-require to fix transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lasso-minify-css": "^1.0.0",
     "lasso-minify-js": "^1.1.4",
     "lasso-package-root": "^1.0.0",
-    "lasso-require": "^3.0.0",
+    "lasso-require": "^3.1.1",
     "lasso-resolve-css-urls": "^2.0.0",
     "lasso-resolve-from": "^1.0.2",
     "marko": "^3.0.0",


### PR DESCRIPTION
When using lasso-babel-transform, I received the following error:

```javascript
node_modules/lasso-tools/node_modules/lasso/node_modules/lasso-require/src/util/Transforms.js:49
        return input.pipe(transformFunc(path));
                          ^

TypeError: transformFunc is not a function
    at applyTransform (node_modules/lasso-tools/node_modules/lasso/node_modules/lasso-require/src/util/Transforms.js:49:27)
    at DeferredReadable.<anonymous> (node_modules/lasso-tools/node_modules/lasso/node_modules/lasso-require/src/util/Transforms.js:73:19)
    at DeferredReadable._read (node_modules/lasso-tools/node_modules/lasso/lib/util/DeferredReadable.js:73:38)
    at DeferredReadable.Readable.read (_stream_readable.js:336:10)
    at resume_ (_stream_readable.js:726:12)
    at nextTickCallbackWith2Args (node.js:442:9)
    at process._tickDomainCallback (node.js:397:17)
```

Upon further investigation, I found that lasso-require had fixed this bug in a new version.