### PR TITLE
upgrade glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "app-root-dir": "^1.0.0",
     "async": "^0.9.0",
     "browser-refresh-client": "^1.0.0",
-    "glob": "^4.0.6",
+    "glob": "^7.1.1",
     "lasso-caching-fs": "^1.0.1",
     "lasso-image": "^1.0.9",
     "lasso-minify-css": "^1.0.0",


### PR DESCRIPTION
Updates `package.json` to use the latest version of `glob`. This should stop those npm errors:
```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

The primary usage of the module hasn't changed much, and the single use of it in the repo looks like it's fine (and the glob tests still pass). 