### PR TITLE
Fixes #180 - Defining bundles with "intersection" does not work for "require" dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 ## 2.8.x
 
+### 2.8.2
+
+- Fixed #180 - Defining bundles with "intersection" does not work for "require" dependencies
+
 ### 2.8.1
 
 - Fixed #178 - Cache key changes when lasso is reconfigured even if config did not change

--- a/lib/dependencies/dependency-intersection.js
+++ b/lib/dependencies/dependency-intersection.js
@@ -1,5 +1,7 @@
+'use strict';
+
 var dependencyWalker = require('../dependency-walker');
-var parallel = require('raptor-async/parallel');
+var series = require('raptor-async/series');
 var DependencyList = require('../DependencyList');
 
 var thresholdRegex = /^(\d+)([%]*)$/;
@@ -81,36 +83,58 @@ module.exports = {
 
             var asyncTasks = dependencies.map(function(dependency, i) {
                 return function(callback) {
-                    dependencyWalker.walk({
-                            lassoContext: lassoContext,
-                            dependency: dependency,
-                            flags: flags,
-                            on: {
-                                dependency: function(dependency, context) {
-                                    if (!dependency.isPackageDependency()) {
-                                        var info = tracking[dependency.getKey()];
-                                        if (info === undefined) {
-                                            tracking[dependency.getKey()] = {
-                                                dependency: dependency,
-                                                count: 1
-                                            };
-                                        } else {
-                                            info.count++;
-                                        }
+                    // HACK: The built-in `dep-require` dependency type
+                    // uses its `Deduper` instance to ignore dependencies
+                    // within the same "phase" of a lasso operation.
+                    //
+                    // However, for the purposes of calculating intersection
+                    // we should not de-duplicate across each "walk" of
+                    // starting dependency.
+                    //
+                    // The `Deduper` stores a cache of "visited" dependencies in
+                    // `lassoContext.phaseData['dependency-require']`.
+                    //
+                    // We reset the `phaseData` property to remove this
+                    // cache before we walk each starting dependency.
+                    let oldPhaseData = lassoContext.phaseData;
+                    lassoContext.phaseData = {};
 
-                                        if ((i === 0) && strictIntersection) {
-                                            // strict intersection so only need to keep track
-                                            // dependencies from first set (which is a little
-                                            // arbitrary but will work)
-                                            firstSet.push(dependency);
-                                        }
+                    dependencyWalker.walk({
+                        lassoContext: lassoContext,
+                        dependency: dependency,
+                        flags: flags,
+                        on: {
+                            dependency: function(dependency, context) {
+                                if (!dependency.isPackageDependency()) {
+                                    var info = tracking[dependency.getKey()];
+                                    if (info === undefined) {
+                                        tracking[dependency.getKey()] = {
+                                            dependency: dependency,
+                                            count: 1
+                                        };
+                                    } else {
+                                        info.count++;
+                                    }
+
+                                    if ((i === 0) && strictIntersection) {
+                                        // strict intersection so only need to keep track
+                                        // dependencies from first set (which is a little
+                                        // arbitrary but will work)
+                                        firstSet.push(dependency);
                                     }
                                 }
                             }
-                        }, callback);
+                        }
+                    }, function(err, result) {
+                        lassoContext.phaseData = oldPhaseData;
+                        callback(err, result);
+                    });
                 };
             });
-            parallel(asyncTasks, function(err) {
+
+            // Use `series` since de-duplication logic in
+            // phase data can interfere with results.
+            series(asyncTasks, function(err) {
                 if (err) {
                     return callback(err);
                 }

--- a/test/autotests/bundling/intersection-threshold-2-require/a.js
+++ b/test/autotests/bundling/intersection-threshold-2-require/a.js
@@ -1,0 +1,2 @@
+'THIS_IS_A'
+require('./shared');

--- a/test/autotests/bundling/intersection-threshold-2-require/b.js
+++ b/test/autotests/bundling/intersection-threshold-2-require/b.js
@@ -1,0 +1,2 @@
+'THIS_IS_B'
+require('./shared');

--- a/test/autotests/bundling/intersection-threshold-2-require/main.browser.json
+++ b/test/autotests/bundling/intersection-threshold-2-require/main.browser.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": [
+        "require: ./a",
+        "require: ./b"
+    ]
+}

--- a/test/autotests/bundling/intersection-threshold-2-require/package.json
+++ b/test/autotests/bundling/intersection-threshold-2-require/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "test-bundling-project",
+    "version": "0.0.0"
+}

--- a/test/autotests/bundling/intersection-threshold-2-require/shared.js
+++ b/test/autotests/bundling/intersection-threshold-2-require/shared.js
@@ -1,0 +1,1 @@
+'THIS_IS_SHARED'

--- a/test/autotests/bundling/intersection-threshold-2-require/test.js
+++ b/test/autotests/bundling/intersection-threshold-2-require/test.js
@@ -1,0 +1,43 @@
+var expect = require('chai').expect;
+var path = require('path');
+
+exports.getLassoConfig = function() {
+    return {
+        fingerprintsEnabled: false,
+        bundles: [
+            {
+                name: 'common',
+                dependencies: [
+                    {
+                        intersection: [
+                            'require: ./a',
+                            'require: ./b'
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+};
+
+exports.getInputs = function() {
+    return [
+        {
+            lassoOptions: {
+                dependencies: [
+                    path.join(__dirname, 'main.browser.json')
+                ]
+            },
+            check(lassoPageResult, writerTracker) {
+                expect(writerTracker.getOutputFilenames()).to.deep.equal([
+                    'bundling-intersection-threshold-2-require.js',
+                    'common.js'
+                ]);
+
+                expect(writerTracker.getCodeForFilename('common.js')).to.contain('THIS_IS_SHARED');
+                expect(writerTracker.getCodeForFilename('bundling-intersection-threshold-2-require.js')).to.contain('THIS_IS_A');
+                expect(writerTracker.getCodeForFilename('bundling-intersection-threshold-2-require.js')).to.contain('THIS_IS_B');
+            }
+        }
+    ];
+};


### PR DESCRIPTION
Defining bundles with "intersection" does not work for "require" dependencies.

`dependency-require` uses data in `lasso-context.phaseData['dependency-require']` to avoid walking the same dependency multiple times. It seems like a hack, but I simply reset the `lassoContext.phaseData` object before walking the dependencies and then I restore the old phase data when done.

See https://github.com/lasso-js/lasso-require/blob/master/src/util/Deduper.js#L20