### PR TITLE
use renderToString instead of renderSync

### DIFF
--- a/lib/LassoPageResult.js
+++ b/lib/LassoPageResult.js
@@ -111,7 +111,7 @@ LassoPageResult.prototype = {
         if (!template) {
             return '';
         }
-        return template.renderSync(data || EMPTY_OBJECT);
+        return template.renderToString(data || EMPTY_OBJECT);
     },
 
     _getSlotTemplate: function(slotName) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lasso-require": "^3.2.2",
     "lasso-resolve-css-urls": "^2.0.0",
     "lasso-resolve-from": "^1.0.2",
-    "marko": "^3.0.0",
+    "marko": "^3.12.1",
     "mime": "~1.2.7",
     "mkdirp": "^0.5.0",
     "property-handlers": "^1.0.0",


### PR DESCRIPTION
This was throwing warnings in parent projects. I only updated this one instance, and did not go through the whole repo and update similar potential changes in tests.

Theoretically this now needs a recent marko version, so I updated that in the package.json, but that would also probably make this more than a semver patch.