### PR TITLE
Fix for broken timeout parameter

### DIFF
--- a/taglib/config-tag.js
+++ b/taglib/config-tag.js
@@ -4,6 +4,8 @@ module.exports = function render(input, out) {
     var lassoRenderContext = getLassoRenderContext(out);
     var config = lassoRenderContext.data.config = Object.assign({}, input);
 
+    lassoRenderContext.data.timeout = input.timeout || 30000 /* 30s */;
+
     if (config.packagePath) {
         config.dependencies = [config.packagePath];
         delete config.packagePath;


### PR DESCRIPTION
The switch from `page-tag` to `config-tag` in [this PR](https://github.com/lasso-js/lasso/commit/0657b12b3b02395b4f16ea3f5cd59931fcb571b0) is breaking our builds, since `slot-tag.js` reads the timeout parameter from `lassoRenderContext.data.timeout`.