### PR TITLE
added buildBundleCacheKey analogous to buildResourceCacheKey

### DIFF
--- a/lib/Lasso.js
+++ b/lib/Lasso.js
@@ -795,6 +795,14 @@ Lasso.prototype = {
             var lassoCache = this.getLassoCache(lassoContext);
             var cacheKey = options.cacheKey || options.pageName || options.name;
 
+            var writer = this.writer;
+
+            var buildBundleCacheKey = writer.buildBundleCacheKey;
+
+            if (buildBundleCacheKey) {
+                cacheKey = buildBundleCacheKey.call(writer, cacheKey, lassoContext);
+            }
+
             lassoCache.getLassoPageResult(
                 cacheKey,
                 {

--- a/lib/writers/Writer.js
+++ b/lib/writers/Writer.js
@@ -306,6 +306,14 @@ Writer.prototype = {
         } else {
             return cacheKey;
         }
+    },
+
+    buildBundleCacheKey(cacheKey, lassoContext) {
+        if (this.impl.buildBundleCacheKey) {
+          return this.impl.buildBundleCacheKey(cacheKey, lassoContext);
+        } else {
+          return cacheKey;
+        }
     }
 };
 


### PR DESCRIPTION
There was no `buildResourceCacheKey` equivalent for bundles, so I added one.