### PR TITLE
Upgrade esprima - Fixes #225

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "buffer": "^4.5.1",
     "clone": "^0.1.19",
     "escodegen": "^1.6.0",
-    "esprima": "^2.7.2",
+    "esprima": "^4.0.0",
     "estraverse": "^4.2.0",
     "events": "^1.0.2",
     "glob": "^7.1.1",


### PR DESCRIPTION
This fixes #225.

NOTE: We have a bit of a dependency problem because `marko-starter` and `marko-magic` pull in different versions of `lasso`.  We need to upgrade `lasso` in `marko-starter` and make `lasso` a peer dependency in `marko-magic`.

I have a PR to fix `marko-magic`. See https://github.com/mlrawlings/marko-magic/pull/1