### PR TITLE
Upgrade marko templates to use spread attribute syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lasso-modules-client": "^2.0.5",
     "lasso-package-root": "^1.0.1",
     "lasso-resolve-from": "^1.2.0",
-    "marko": "^4.2.8",
+    "marko": "^4.9.0",
     "mime": "^1.2.11",
     "mkdirp": "^0.5.1",
     "path-browserify": "0.0.0",

--- a/src/Lasso.js
+++ b/src/Lasso.js
@@ -68,6 +68,24 @@ function isExternalUrl(path) {
     return urlRegExp.test(path);
 }
 
+function stringifyAttributes (obj) {
+    var str = '';
+    for (var key in obj) {
+        var val = obj[key];
+        if (val === false || val == null) {
+            continue;
+        }
+
+        str += ' ' + key;
+
+        if (val !== true) {
+            str += '=' + JSON.stringify(val);
+        }
+    }
+
+    return str;
+}
+
 async function getLassoManifestFromOptions (options, dependencyRegistry) {
     var lassoManifest;
     var from = options.from;
@@ -717,11 +735,11 @@ Lasso.prototype = {
     },
 
     getJavaScriptDependencyHtml: function(url, attributes) {
-        return '<script src=' + JSON.stringify(url) + ' ${Object.assign(' + JSON.stringify(attributes || null) + ' || {}, data.externalScriptAttrs)}></script>';
+        return '<script ...data.externalScriptAttrs' + stringifyAttributes(Object.assign({ src: url }, attributes)) + '></script>';
     },
 
     getCSSDependencyHtml: function(url, attributes) {
-        return '<link rel="stylesheet" href=' + JSON.stringify(url) + ' ${Object.assign(' + JSON.stringify(attributes || null) + ' || {}, data.externalStyleAttrs)}>';
+        return '<link ...data.externalStyleAttrs' + stringifyAttributes(Object.assign({ rel: 'stylesheet', href: url }, attributes)) + '>';
     },
 
     _resolveflags: function(options) {

--- a/src/Slot.js
+++ b/src/Slot.js
@@ -36,9 +36,9 @@ Slot.prototype = {
             var content = this.content[i];
             if (content.inline) {
                 if (this.contentType === 'js') {
-                    output.push('<script ${data.inlineScriptAttrs} marko-body="static-text">' + content.code + '</script>'); // eslint-disable-line no-template-curly-in-string
+                    output.push('<script ...data.inlineScriptAttrs marko-body="static-text">' + content.code + '</script>'); // eslint-disable-line no-template-curly-in-string
                 } else if (this.contentType === 'css') {
-                    output.push('<style ${data.inlineStyleAttrs} marko-body="static-text">' + content.code + '</style>'); // eslint-disable-line no-template-curly-in-string
+                    output.push('<style ...data.inlineStyleAttrs marko-body="static-text">' + content.code + '</style>'); // eslint-disable-line no-template-curly-in-string
                 }
             } else {
                 output.push(content.code);


### PR DESCRIPTION
This fixes console warnings when using lasso with the latest version of Marko where the old attribute spread syntax has been deprecated.