### PR TITLE
Support Node.js >= v10 with proper SemVer check

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,1 +1,1 @@
-exports.compatible = process.version >= 'v8.0.0';
+exports.compatible = require('semver').satisfies(process.version, '>=8.0.0');

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "raptor-strings": "^1.0.2",
     "raptor-util": "^3.2.0",
     "resolve-from": "^1.0.1",
+    "semver": "^5.5.0",
     "send": "^0.13.2",
     "stream-browserify": "^1.0.0",
     "string_decoder": "^0.10.31",


### PR DESCRIPTION
Node.js >=v10 was recognized as >= v8.0, triggering the compat mode.
The right thing to do seems to use the semver module.

Tests pass locally fine except:

* lasso-lassoResource-buffer: `expected '/static/cf6691ad.png' to equal '/static/02827b0c.png'`
* lasso-lassoResource-buffer-name: `expected '/static/test-cf6691ad.png' to equal '/static/test-02827b0c.png'`

I use the nodejs-10.1.0-1 package on Arch Linux.
`tag/v3.1.5` fails in the same way. 
Maybe a random number generator seed change ?