### PR TITLE
Move setting the cache of the lassoContext to be last

### DIFF
--- a/src/Lasso.js
+++ b/src/Lasso.js
@@ -797,8 +797,11 @@ Lasso.prototype = {
         lassoContext.config = this.config;
         lassoContext.writer = writer;
         lassoContext.lasso = this;
-        lassoContext.cache = this.getLassoCache(lassoContext);
         lassoContext.options = options;
+        // cache must come last so that all of the data above will
+        // be available on the lassoContext that will be part of the subsequent
+        // payload of the event that will be emitted after the cache is fetched.
+        lassoContext.cache = this.getLassoCache(lassoContext);
 
         return lassoContext;
     },


### PR DESCRIPTION
Two events are fired after the cache is set on the lassoContext:
- lassoCacheCreated
- buildCacheKey

The payload of `lassoCacheCreated` actually includes `lassoContext.options`. But since options is set after the cache is set, it will always be undefined.

`buildCacheKey` also includes the lassoContext in its event payload, so this would allow `options` to also be available there.