### PR TITLE
Fix displaying errors when minification fails.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,14 +236,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "app-module-path": {
       "version": "2.2.0",
@@ -353,7 +351,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -1221,7 +1218,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -1637,8 +1633,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.10.0",
@@ -2280,7 +2275,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -2753,8 +2747,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -6407,7 +6400,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -6426,8 +6418,7 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "table": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "app-root-dir": "^1.0.2",
     "assert": "^1.4.1",
+    "babel-code-frame": "^6.26.0",
     "browser-refresh-client": "^1.1.4",
     "buffer": "^5.1.0",
     "clean-css": "^4.1.11",

--- a/src/plugins/lasso-minify-js/index.js
+++ b/src/plugins/lasso-minify-js/index.js
@@ -1,4 +1,5 @@
 var UglifyJS = require('uglify-js');
+var codeFrame = require('babel-code-frame');
 var internalOptions = ['inlineOnly'];
 var hasOwn = Object.prototype.hasOwnProperty;
 
@@ -10,7 +11,13 @@ function minify(src, pluginOptions) {
         }
     }
 
-    return UglifyJS.minify(src, minifyOptions).code;
+    var result = UglifyJS.minify(src, minifyOptions);
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    return result.code;
 }
 
 function isInline(lassoContext) {
@@ -48,10 +55,8 @@ module.exports = function (lasso, pluginConfig) {
             } catch (e) {
                 if (e.line) {
                     var dependency = lassoContext.dependency;
-                    console.error('Unable to minify the following code for ' + dependency + ' at line ' + e.line + ' column ' + e.col + ':\n' +
-                                  '------------------------------------\n' +
-                                  code + '\n' +
-                                  '------------------------------------\n');
+                    var frame = codeFrame(code, e.line, e.col, { highlightCode: true });
+                    console.error(e.message + ' in ' + dependency + ' at line ' + e.line + ' column ' + e.col + ':\n' + frame);
                     return code;
                 } else {
                     throw e;


### PR DESCRIPTION
Looks like previously uglify js threw errors when it couldn't minify a file, now it returns an object which was tripping us up.

This now throws the error properly from uglify js and I brought in `babel-code-frame` to make the error message a bit prettier.