### PR TITLE
Show formatted parse for requires.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage
 .nyc_output/
 dist-compat/
 test-dist-compat/
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,16 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "char-props": {
@@ -6397,11 +6407,20 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "nyc": "^12.0.2",
     "require-self-ref": "^2.0.1",
     "shelljs": "^0.8.2",
-    "sinon": "^6.0.0"
+    "sinon": "^6.0.0",
+    "strip-ansi": "^4.0.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/require/inspect-cache.js
+++ b/src/require/inspect-cache.js
@@ -88,13 +88,13 @@ exports.inspectCached = function(path, requireHandler, lassoContext, config) {
         fromCache = false;
         return readSource()
             .then((src) => {
-                return inspect(src);
+                return inspect(src, { filename: path });
             });
     }
 
     function afterInspect (inspectResult) {
         if (debugEnabled) {
-            logger.debug('Inspection result for ' + path + ': ' + JSON.stringify(inspect));
+            logger.debug('Inspection result for ' + path + ': ' + JSON.stringify(inspectResult));
         }
 
         // Do a shallow clonse so that we don't modify the object stored in the cache

--- a/test/autotests/inspect/parse-error/expected.json
+++ b/test/autotests/inspect/parse-error/expected.json
@@ -1,0 +1,4 @@
+{
+    "name": "SyntaxError",
+    "message": "Unexpected token ...\n> 1 | const thing = { ...stuff };\n    |                 ^\n  2 | require('foo');\n  3 | \n  4 | if (require('bar')) {"
+}

--- a/test/autotests/inspect/parse-error/input.js
+++ b/test/autotests/inspect/parse-error/input.js
@@ -1,0 +1,6 @@
+const thing = { ...stuff };
+require('foo');
+
+if (require('bar')) {
+    require('baz');
+}

--- a/test/inspect-test.js
+++ b/test/inspect-test.js
@@ -3,6 +3,7 @@ require('./util/test-init');
 
 const nodePath = require('path');
 const chai = require('chai');
+const stripAnsi = require('strip-ansi');
 chai.config.includeStack = true;
 const fs = require('fs');
 const inspect = require('lasso/require/util/inspect');
@@ -13,7 +14,16 @@ describe('lasso-require/util/inspect', function() {
         async function (dir, helpers) {
             const inputPath = nodePath.join(dir, 'input.js');
             const inputSrc = fs.readFileSync(inputPath, { encoding: 'utf8' });
-            const inspected = inspect(inputSrc, { allowShortcircuit: false });
-            helpers.compare(inspected, '.json');
+            try {
+                const inspected = inspect(inputSrc, { filename: inputPath, allowShortcircuit: false });
+                helpers.compare(inspected, '.json');
+            } catch (err) {
+                var message = stripAnsi(err.message);
+                message = message.slice(message.indexOf("): ") + 3);
+                helpers.compare({
+                    name: err.name,
+                    message: message
+                }, '.json');
+            }
         });
 });


### PR DESCRIPTION
Currently lasso doesn't properly display errors when it fails to parse the require's of a js file and just includes the source as is.

This change throws when the parsing fails with a formatted error.