### PR TITLE
add css resolve exception for css behavior prop

### DIFF
--- a/src/plugins/lasso-resolve-css-urls/index.js
+++ b/src/plugins/lasso-resolve-css-urls/index.js
@@ -61,6 +61,11 @@ function replaceUrls (code, lassoContext, urlResolver) {
             // the replacer function
             async function (url, start, end, callback) {
                 try {
+                    // add exception for css properies with hash e.g. behavior: url(#default#VML);
+                    if(url.startsWith('#')) {
+                        return callback(null, url);
+                    }
+
                     const resolvedUrl = await urlResolver(url, lassoContext);
                     const bundledResource = await lasso.lassoResource(resolvedUrl, { lassoContext });
                     callback(null, bundledResource && bundledResource.url);


### PR DESCRIPTION
Lasso encountered an error while trying to resolve
`behavior: url(#default#VML);`

This is some css extensions for IE browsers. Propose to add a url resolve exception for urls beginning with a '#'.