### PR TITLE
Include WEBP in browser-refresh imageExtensions

### DIFF
--- a/src/browser-refresh/index.js
+++ b/src/browser-refresh/index.js
@@ -7,7 +7,8 @@ var styleExtensions = {
     styl: true,
     stylus: true,
     scss: true,
-    sass: true
+    sass: true,
+    webp: true
 };
 
 var imageExtensions = {


### PR DESCRIPTION
The default pattern watches for `*.webp`, but `.refreshImages()` isn’t called when WEBP files change.