### PR TITLE
feat: switch to espree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,27 +187,14 @@
       }
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
-      "dev": true
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -1716,6 +1703,29 @@
         "text-table": "~0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1749,6 +1759,16 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "globals": {
@@ -1874,13 +1894,20 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-      "dev": true,
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        }
       }
     },
     "esprima": {
@@ -3265,6 +3292,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4207,7 +4235,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clone": "^2.1.1",
     "complain": "^1.2.0",
     "escodegen": "^1.10.0",
-    "esprima": "^4.0.0",
+    "espree": "^7.3.0",
     "estraverse": "^4.2.0",
     "events": "^3.0.0",
     "glob": "^7.1.2",

--- a/src/require/util/inspect.js
+++ b/src/require/util/inspect.js
@@ -1,12 +1,14 @@
 var path = require('path');
-var esprima = require('esprima');
+var espree = require('espree');
 var codeFrame = require('babel-code-frame');
 var estraverse = require('estraverse');
 var ok = require('assert').ok;
 var cwd = process.cwd();
 
 var parseOpts = {
-    range: true
+    range: true,
+    sourceType: 'script',
+    ecmaVersion: espree.latestEcmaVersion
 };
 
 var shortCircuitRegExp = /require\(|require\.resolve\(|.async\(|#async|process|Buffer/;
@@ -217,9 +219,9 @@ module.exports = function inspect(src, options) {
 
     var parsedAst;
     try {
-        parsedAst = esprima.parse(src, parseOpts);
+        parsedAst = espree.parse(src, parseOpts);
     } catch (err) {
-        if (!err.description) {
+        if (!err.lineNumber) {
             throw err;
         }
 
@@ -230,7 +232,7 @@ module.exports = function inspect(src, options) {
         }
 
         var frame = codeFrame(src, err.lineNumber, err.column, { highlightCode: true });
-        throw new SyntaxError(errorLoc + err.description + '\n' + frame);
+        throw new SyntaxError(errorLoc + err.message + '\n' + frame);
     }
 
     estraverse.traverse(parsedAst, {

--- a/test/autotests/inspect/parse-error/expected.json
+++ b/test/autotests/inspect/parse-error/expected.json
@@ -1,4 +1,4 @@
 {
     "name": "SyntaxError",
-    "message": "Unexpected token ...\n> 1 | const thing = { ...stuff };\n    |                 ^\n  2 | require('foo');\n  3 | \n  4 | if (require('bar')) {"
+    "message": "Unexpected token ;\n> 1 | const thing = {;\n    |                ^\n  2 | require('foo');\n  3 | \n  4 | if (require('bar')) {"
 }

--- a/test/autotests/inspect/parse-error/input.js
+++ b/test/autotests/inspect/parse-error/input.js
@@ -1,4 +1,4 @@
-const thing = { ...stuff };
+const thing = {;
 require('foo');
 
 if (require('bar')) {


### PR DESCRIPTION
Switches from the (largely abandond) esprima parser to espree (maintained by the eslint team).
This allows lasso to parse some modern JS without the need for babel.