### PR TITLE
Add bundleReadTimeout info to timeout error message

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -166,7 +166,7 @@ function createReadBundleStream(bundle, lassoContext, transformerAsyncValue) {
 
     function onTimeout() {
         var dependency = dependencies[curIndex];
-        var message = 'Reading dependency timed out after ' + timeout + 'ms: ' + dependency.toString();
+        var message = 'Reading dependency timed out after ' + timeout + 'ms: ' + dependency.toString() + '. The timeout value can be set via the bundleReadTimeout configuration option (defaults to ' + exports.DEFAULT_READ_TIMEOUT + ').';
         combinedStream.emit('error', new Error(message));
 
         combinedStream.forEachStream(function(stream) {


### PR DESCRIPTION
Ran into this recently. Fixes #71 
One alternative might be to only show the additional info if `timeout === DEFAULT_READ_TIMEOUT`.