### PR TITLE
feat: remove Marko as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -230,20 +230,10 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "app-module-path": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
-    },
     "app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
       "integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg="
-    },
-    "argly": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/argly/-/argly-1.2.0.tgz",
-      "integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
     },
     "argparse": {
       "version": "1.0.10",
@@ -320,7 +310,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1222,11 +1213,6 @@
         }
       }
     },
-    "char-props": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
-      "integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4="
-    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -1446,21 +1432,6 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-        }
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1534,23 +1505,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "deresolve": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
-      "integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
-      "requires": {
-        "lasso-package-root": "^1.0.0",
-        "raptor-polyfill": "^1.0.2",
-        "resolve-from": "^1.0.1"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-        }
-      }
     },
     "destroy": {
       "version": "1.0.4",
@@ -1913,7 +1867,8 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -1952,26 +1907,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
-    },
-    "events-light": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
-      "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
-      "requires": {
-        "chai": "^3.5.0"
-      },
-      "dependencies": {
-        "chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-          "requires": {
-            "assertion-error": "^1.0.1",
-            "deep-eql": "^0.1.3",
-            "type-detect": "^1.0.0"
-          }
-        }
-      }
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -2357,7 +2292,8 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -2374,15 +2310,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
-    },
-    "htmljs-parser": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.3.2.tgz",
-      "integrity": "sha1-HMW/mCSgkcKIILM+r3gIOo6qhWw=",
-      "requires": {
-        "char-props": "^0.1.5",
-        "complain": "^1.0.0"
-      }
     },
     "http-errors": {
       "version": "1.6.3",
@@ -2919,11 +2846,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "listener-tracker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/listener-tracker/-/listener-tracker-2.0.0.tgz",
-      "integrity": "sha1-OWCLQ1wJAfpVECF8FFJyjWvBm18="
-    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -3012,56 +2934,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "marko": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/marko/-/marko-4.10.0.tgz",
-      "integrity": "sha512-J9c2f/YsG/s9BI4Qnlvy2ASsAff7Qt7nNLgpk5eBjDDa2TLfyKXIxLeDkaVPnPd358Esz41XUcMlwSygR4nKow==",
-      "requires": {
-        "app-module-path": "^2.2.0",
-        "argly": "^1.0.0",
-        "browser-refresh-client": "^1.0.0",
-        "char-props": "~0.1.5",
-        "complain": "^1.2.0",
-        "deresolve": "^1.1.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "estraverse": "^4.2.0",
-        "events": "^1.0.2",
-        "events-light": "^1.0.0",
-        "he": "^1.1.0",
-        "htmljs-parser": "^2.3.2",
-        "lasso-caching-fs": "^1.0.1",
-        "lasso-modules-client": "^2.0.4",
-        "lasso-package-root": "^1.0.1",
-        "listener-tracker": "^2.0.0",
-        "minimatch": "^3.0.2",
-        "object-assign": "^4.1.0",
-        "property-handlers": "^1.0.0",
-        "raptor-json": "^1.0.1",
-        "raptor-polyfill": "^1.0.0",
-        "raptor-promises": "^1.0.1",
-        "raptor-regexp": "^1.0.0",
-        "raptor-util": "^3.2.0",
-        "resolve-from": "^2.0.0",
-        "shorthash": "0.0.2",
-        "simple-sha1": "^2.1.0",
-        "strip-json-comments": "^2.0.1",
-        "try-require": "^1.2.1",
-        "warp10": "^1.0.0"
-      },
-      "dependencies": {
-        "events": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-        }
       }
     },
     "micromatch": {
@@ -5311,7 +5183,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5662,14 +5535,6 @@
       "resolved": "https://registry.npmjs.org/raptor-detect/-/raptor-detect-1.0.1.tgz",
       "integrity": "sha1-ClTGOQVu9m39Ur45RfoizG0UZvM="
     },
-    "raptor-json": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
-      "integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
-      "requires": {
-        "raptor-strings": "^1.0.0"
-      }
-    },
     "raptor-logging": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/raptor-logging/-/raptor-logging-1.1.3.tgz",
@@ -5975,11 +5840,6 @@
         "is-promise": "^2.1.0"
       }
     },
-    "rusha": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
-      "integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -6107,24 +5967,11 @@
         "rechoir": "^0.6.2"
       }
     },
-    "shorthash": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
-      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
-    },
-    "simple-sha1": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
-      "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
-      "requires": {
-        "rusha": "^0.8.1"
-      }
     },
     "sinon": {
       "version": "6.0.0",
@@ -6624,11 +6471,6 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
-    "try-require": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
-      "integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -6636,11 +6478,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -6792,11 +6629,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "warp10": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/warp10/-/warp10-1.3.6.tgz",
-      "integrity": "sha512-7cijX+NprqPV+UGUZXZw1I15JFHPqoy65tNVvP6cL43Vlanpcm8hBYoQTuDYUHa5x90Bct4gHhRtqqOOkLhQkw=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lasso-modules-client": "^2.0.5",
     "lasso-package-root": "^1.0.1",
     "lasso-resolve-from": "^1.2.0",
-    "marko": "^4.10.0",
     "mime": "^2.3.1",
     "mkdirp": "^0.5.1",
     "path-browserify": "1.0.0",

--- a/src/Lasso.js
+++ b/src/Lasso.js
@@ -30,6 +30,7 @@ const LassoPrebuildResult = require('./LassoPrebuildResult');
 const readFileAsync = promisify(fs.readFile);
 const { buildPrebuildName, buildPrebuildFileName } = require('./util/prebuild.js');
 const hashUtil = require('./util/hash');
+const stringifyAttrs = require('./util/stringify-attrs');
 
 /**
 * Cache of prebuilds by path. If there are multiple slots for the same
@@ -75,24 +76,6 @@ const resourceHandlersByType = {
 
 function isExternalUrl(path) {
     return urlRegExp.test(path);
-}
-
-function stringifyAttributes (obj) {
-    var str = '';
-    for (var key in obj) {
-        var val = obj[key];
-        if (val === false || val == null) {
-            continue;
-        }
-
-        str += ' ' + key;
-
-        if (val !== true) {
-            str += '=' + JSON.stringify(val);
-        }
-    }
-
-    return str;
 }
 
 async function getLassoManifestFromOptions (options, dependencyRegistry) {
@@ -744,11 +727,11 @@ Lasso.prototype = {
     },
 
     getJavaScriptDependencyHtml: function(url, attributes) {
-        return '<script ...data.externalScriptAttrs' + stringifyAttributes(Object.assign({ src: url }, attributes)) + '></script>';
+        return '<script' + stringifyAttrs(Object.assign({ src: url }, attributes)) + '%LASSO_ATTRS externalScriptAttrs%></script>';
     },
 
     getCSSDependencyHtml: function(url, attributes) {
-        return '<link ...data.externalStyleAttrs' + stringifyAttributes(Object.assign({ rel: 'stylesheet', href: url }, attributes)) + '>';
+        return '<link' + stringifyAttrs(Object.assign({ rel: 'stylesheet', href: url }, attributes)) + '%LASSO_ATTRS externalStyleAttrs%>';
     },
 
     _resolveflags: function(options) {

--- a/src/LassoPageResult.js
+++ b/src/LassoPageResult.js
@@ -1,21 +1,7 @@
 var extend = require('raptor-util/extend');
-var marko = require('marko');
-var nodePath = require('path');
 const LassoPrebuild = require('./LassoPrebuild');
+const stringifyAttrs = require('./util/stringify-attrs');
 var EMPTY_OBJECT = {};
-
-function generateTempFilename(slotName) {
-    // Generates a unique filename based on date/time and, process ID and a random number
-    var now = new Date();
-    return [
-        slotName,
-        now.getYear(),
-        now.getMonth(),
-        now.getDate(),
-        process.pid,
-        (Math.random() * 0x100000000 + 1).toString(36)
-    ].join('-') + '.marko';
-}
 
 function LassoPageResult (options = {}) {
     const { htmlBySlot, resources, isPrebuild } = options;
@@ -133,17 +119,45 @@ LassoPageResult.prototype = {
                     }
                 };
             } else {
-                // In order to compile the HTML for the slot into a Marko template, we need to provide a faux
-                // template path. The path doesn't really matter unless the compiled template needs to import
-                // external tags or templates.
-                var templatePath = nodePath.resolve(__dirname, '..', generateTempFilename(slotName));
-                template = marko.load(templatePath, templateSrc, { preserveWhitespace: true, writeToDisk: false });
-                // Cache the loaded template:
-                this._htmlTemplatesBySlot[slotName] = template;
+                template = this._htmlTemplatesBySlot[slotName] = {
+                    renderToString(input) {
+                        var isAsync = false;
+                        var isDeferred = false;
+                        var scriptAttrs = input.externalScriptAttrs;
 
-                // The Marko template compiled to JS and required. Let's delete it out of the require cache
-                // to avoid a memory leak
-                delete require.cache[templatePath + '.js'];
+                        if (scriptAttrs) {
+                            if (scriptAttrs.async) {
+                                isAsync = true;
+                            } else if (scriptAttrs.defer) {
+                                isDeferred = true;
+                            }
+                        }
+
+                        return templateSrc.replace(/%LASSO_ATTRS (\w+)%/g, (_, key) => {
+                            return stringifyAttrs(input[key]);
+                        }).replace(/%LASSO_CONDITION (\w+)%([\s\S]*?)%LASSO_CONDITION_END%/g, (_, condition, code) => {
+                            switch (condition) {
+                            case 'isAsync':
+                                if (isAsync) {
+                                    return code;
+                                }
+                                break;
+                            case 'isDeferred':
+                                if (isDeferred) {
+                                    return code;
+                                }
+                                break;
+                            case 'isSync':
+                                if (!(isAsync || isDeferred)) {
+                                    return code;
+                                }
+                                break;
+                            }
+
+                            return '';
+                        });
+                    }
+                };
             }
         }
 

--- a/src/Slot.js
+++ b/src/Slot.js
@@ -40,9 +40,9 @@ Slot.prototype = {
             var content = this.content[i];
             if (content.inline) {
                 if (this.contentType === 'js') {
-                    output.push('<if(data.externalScriptAttrs && data.externalScriptAttrs.async)><script ...data.inlineScriptAttrs marko-body="static-text">' + this.wrapInDocumentLoaded(content.code, true) + '</script></if><else-if(data.externalScriptAttrs && data.externalScriptAttrs.defer)><script ...data.inlineScriptAttrs marko-body="static-text">' + this.wrapInDocumentLoaded(content.code) + '</script></else-if><else><script ...data.inlineScriptAttrs marko-body="static-text">' + content.code + '</script></else>'); // eslint-disable-line no-template-curly-in-string
+                    output.push('<script%LASSO_ATTRS inlineScriptAttrs%>%LASSO_CONDITION isAsync%' + this.wrapInDocumentLoaded(content.code, true) + '%LASSO_CONDITION_END%%LASSO_CONDITION isDeferred%' + this.wrapInDocumentLoaded(content.code) + '%LASSO_CONDITION_END%%LASSO_CONDITION isSync%' + content.code + '%LASSO_CONDITION_END%</script>'); // eslint-disable-line no-template-curly-in-string
                 } else if (this.contentType === 'css') {
-                    output.push('<style ...data.inlineStyleAttrs marko-body="static-text">' + content.code + '</style>'); // eslint-disable-line no-template-curly-in-string
+                    output.push('<style%LASSO_ATTRS inlineStyleAttrs%>' + content.code + '</style>'); // eslint-disable-line no-template-curly-in-string
                 }
             } else {
                 output.push(content.code);

--- a/src/util/stringify-attrs.js
+++ b/src/util/stringify-attrs.js
@@ -1,0 +1,17 @@
+module.exports = function stringifyAttributes (obj) {
+    var str = '';
+    for (var key in obj) {
+        var val = obj[key];
+        if (val === false || val == null) {
+            continue;
+        }
+
+        str += ' ' + key;
+
+        if (val !== true) {
+            str += '=' + JSON.stringify(val);
+        }
+    }
+
+    return str;
+};

--- a/test/autotests/bundling/escape-external-css-url/test.js
+++ b/test/autotests/bundling/escape-external-css-url/test.js
@@ -21,7 +21,7 @@ exports.getInputs = function() {
             },
             check(lassoPageResult, writerTracker) {
                 expect(lassoPageResult.getBodyHtml()).to.equal('');
-                expect(lassoPageResult.getHeadHtml()).to.equal('<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans&amp;subset=latin">');
+                expect(lassoPageResult.getHeadHtml()).to.equal('<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans&subset=latin">');
             }
         }
     ];

--- a/test/autotests/bundling/escape-external-js-url/test.js
+++ b/test/autotests/bundling/escape-external-js-url/test.js
@@ -20,7 +20,7 @@ exports.getInputs = function() {
                 ]
             },
             check(lassoPageResult, writerTracker) {
-                expect(lassoPageResult.getBodyHtml()).to.equal('<script src="https://maps.googleapis.com/maps/api/js?key=KEY&amp;callback=CB"></script>');
+                expect(lassoPageResult.getBodyHtml()).to.equal('<script src="https://maps.googleapis.com/maps/api/js?key=KEY&callback=CB"></script>');
                 expect(lassoPageResult.getHeadHtml()).to.equal('');
             }
         }

--- a/test/autotests/bundling/external-js-integrity/test.js
+++ b/test/autotests/bundling/external-js-integrity/test.js
@@ -21,7 +21,7 @@ exports.getInputs = function() {
                 ]
             },
             check(lassoPageResult, writerTracker) {
-                expect(lassoPageResult.getBodyHtml()).to.equal('<script src="https://maps.googleapis.com/maps/api/js?key=KEY&amp;callback=CB" integrity="abc123"></script>');
+                expect(lassoPageResult.getBodyHtml()).to.equal('<script src="https://maps.googleapis.com/maps/api/js?key=KEY&callback=CB" integrity="abc123"></script>');
                 expect(lassoPageResult.getHeadHtml()).to.equal('');
             }
         }


### PR DESCRIPTION
This PR removes Marko as a direct dependency.

This is certainly not the greatest way to do it, but I think it should be sufficient for now.

What I've done is replace the Marko templates that were generated and then evaluated by lasso with a few `%EXPRESSIONS` that I can regexp away to achieve the same thing we were doing with the existing Marko templates.